### PR TITLE
fix: avoid sdk import from root

### DIFF
--- a/src/AppActions/Plugin/clientJStorageFetch.js
+++ b/src/AppActions/Plugin/clientJStorageFetch.js
@@ -1,5 +1,5 @@
 import PluginAction from '../PluginAction';
-import {JStorage} from 'rev.sdk.js';
+import * as JStorage from 'rev.sdk.js/Actions/JStorage';
 
 export default class Plugin extends PluginAction {
   shouldExecute(...args) {


### PR DESCRIPTION
As we saw last Friday, this will cause issues~