### PR TITLE
feat: cache site collection

### DIFF
--- a/data.json
+++ b/data.json
@@ -9,5 +9,6 @@
   "storageHost": "https://storage-stg.revtel-api.com/v4",
   "articleEditorHost": "https://console.revtel2.com/article/editor",
   "gaId": "G-1LH69CW4Y1",
-  "gtmId": "GTM-KCRVXBN"
+  "gtmId": "GTM-KCRVXBN",
+  "siteCacheUrl": "https://pokemon-store-revtel2-com-stg.s3.ap-northeast-1.amazonaws.com/rev-site-cache.json"
 }

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -17,6 +17,8 @@ function config() {
     data.articleEditorHost = 'https://console.revtel2.com/article/editor';
     data.gaId = 'G-1LH69CW4Y1';
     data.gtmId = 'GTM-KCRVXBN';
+    data.siteCacheUrl =
+      'https://pokemon-store-revtel2-com-stg.s3.ap-northeast-1.amazonaws.com/rev-site-cache.json';
   } else {
     // https://pokemon.netlify.app
     data.stage = 'prod';
@@ -28,6 +30,8 @@ function config() {
     data.articleEditorHost = 'https://console-prod.netlify.com/article/editor';
     data.gaId = 'G-2324HZCWPM';
     data.gtmId = 'GTM-NJXKB4D';
+    data.siteCacheUrl =
+      'https://pokemon-store-revtel2-com-prod.s3.ap-northeast-1.amazonaws.com/rev-site-cache.json';
   }
 
   fs.writeFileSync('./data.json', JSON.stringify(data, null, 2), 'utf8');

--- a/src/AppActions/index.js
+++ b/src/AppActions/index.js
@@ -356,6 +356,16 @@ async function onAfterAdminFormSubmit(
     });
   }
 
+  if (
+    path.indexOf('/admin/landing') > -1 ||
+    path.indexOf('/admin/product_category') > -1 ||
+    path.indexOf('/admin/article_category') > -1
+  ) {
+    await JStorage.cacheDocuments('site', {}, null, null, null, undefined, {
+      key: 'rev-site-cache.json',
+    });
+  }
+
   return null;
 }
 

--- a/src/AppContext/index.js
+++ b/src/AppContext/index.js
@@ -5,7 +5,9 @@ import ResetPasswordModal from '../Components/ResetPasswordModal';
 import * as JStorage from 'rev.sdk.js/Actions/JStorage';
 import {buildCatDisplayMap} from '../Utils/buildCatDisplayMap';
 import Spinner from 'rev.sdk.js/Components/Spinner';
+import * as ApiUtil from 'rev.sdk.js/Utils/ApiUtil';
 import LoadingGif from '../../static/loading.gif';
+import Config from '../../data.json';
 
 function Provider(props) {
   const Dimension = getOutlet('dimension');
@@ -45,53 +47,38 @@ function Provider(props) {
 
   React.useEffect(() => {
     console.log('AppCtx effect hook');
-    function onCtxRendered() {
-      const PRODUCT_CATEGORY_IN_SESSION_STORAGE = JSON.parse(
-        window.sessionStorage.getItem('categories'),
-      );
-      const ARTICLE_CATEGORY_IN_SESSION_STORAGE = JSON.parse(
-        window.sessionStorage.getItem('articleCategories'),
-      );
+    async function onCtxRendered() {
+      let configs = null;
 
-      if (
-        // PRODUCT_CATEGORY_IN_SESSION_STORAGE &&
-        // ARTICLE_CATEGORY_IN_SESSION_STORAGE
-        false
-      ) {
-        getOutlet('categories').update(PRODUCT_CATEGORY_IN_SESSION_STORAGE);
-        getOutlet('categoryDisplayMap').update(
-          buildCatDisplayMap(PRODUCT_CATEGORY_IN_SESSION_STORAGE),
-        );
-        getOutlet('articleCategories').update(
-          ARTICLE_CATEGORY_IN_SESSION_STORAGE,
-        );
-        getOutlet('articleCategoryDisplayMap').update(
-          buildCatDisplayMap(ARTICLE_CATEGORY_IN_SESSION_STORAGE),
-        );
-      } else {
-        JStorage.fetchDocuments('site', {}, null, null).then((configs) => {
-          for (const cfg of configs) {
-            if (cfg.name === 'product_category') {
-              getOutlet('categories').update(cfg.categories || []);
-              getOutlet('categoryDisplayMap').update(
-                buildCatDisplayMap(cfg.categories || []),
-              );
-              window.sessionStorage.setItem(
-                'categories',
-                JSON.stringify(cfg.categories || []),
-              );
-            } else if (cfg.name === 'article_category') {
-              getOutlet('articleCategories').update(cfg.categories || []);
-              getOutlet('articleCategoryDisplayMap').update(
-                buildCatDisplayMap(cfg.categories || []),
-              );
-              window.sessionStorage.setItem(
-                'articleCategories',
-                JSON.stringify(cfg.categories || []),
-              );
-            }
-          }
-        });
+      if (Config.siteCacheUrl) {
+        try {
+          configs = await ApiUtil.req(Config.siteCacheUrl);
+        } catch (ex1) {
+          console.warn('[AppContext] siteCacheUrl is set but no data');
+        }
+      }
+
+      if (!configs) {
+        try {
+          configs = await JStorage.fetchDocuments('site', {}, null, null);
+        } catch (ex2) {
+          console.warn('[AppContext] fail to fetch site collection');
+          configs = [];
+        }
+      }
+
+      for (const cfg of configs) {
+        if (cfg.name === 'product_category') {
+          getOutlet('categories').update(cfg.categories || []);
+          getOutlet('categoryDisplayMap').update(
+            buildCatDisplayMap(cfg.categories || []),
+          );
+        } else if (cfg.name === 'article_category') {
+          getOutlet('articleCategories').update(cfg.categories || []);
+          getOutlet('articleCategoryDisplayMap').update(
+            buildCatDisplayMap(cfg.categories || []),
+          );
+        }
       }
     }
     onCtxRendered();


### PR DESCRIPTION
This PR caches site collection (for `landing`, `product_category`, and `article_category`), issue is #32

> For this feature to work, we first need to add `cache_bucket` into JStorage's collection setting (ask backend to help).

Add an extra config `siteCacheUrl` into `config.js`:

```javascript
if (process.env.REV_ENV === 'stg') {
    // https://pokemon-stg.netlify.app
    data.stage = 'stg';
   ...
    data.siteCacheUrl =
      'https://pokemon-store-revtel2-com-stg.s3.ap-northeast-1.amazonaws.com/rev-site-cache.json';
  }
```

Add logic into default `AppActions.onAfterAdminFormSubmit`, so once `site` collection is touched, we then update the cache on S3:

```javascript
async function onAfterAdminFormSubmit(
  {path, collection, instance, extValues, formData, primaryKey},
  updatedInstance,
) {
  ...
  if (
    path.indexOf('/admin/landing') > -1 ||
    path.indexOf('/admin/product_category') > -1 ||
    path.indexOf('/admin/article_category') > -1
  ) {
    await JStorage.cacheDocuments('site', {}, null, null, null, undefined, {
      key: 'rev-site-cache.json',
    });
  }
  return null;
}
```

Add logic to fetch data from cache (if configured) with fallback in `AppContext/index.js`:

```javascript
    async function onCtxRendered() {
      let configs = null;

      if (Config.siteCacheUrl) {
        try {
          configs = await ApiUtil.req(Config.siteCacheUrl);
        } catch (ex1) {
          console.warn('[AppContext] siteCacheUrl is set but no data');
        }
      }

      if (!configs) {
        try {
          configs = await JStorage.fetchDocuments('site', {}, null, null);
        } catch (ex2) {
          console.warn('[AppContext] fail to fetch site collection');
          configs = [];
        }
      }

      for (const cfg of configs) {
        if (cfg.name === 'product_category') {
          getOutlet('categories').update(cfg.categories || []);
          getOutlet('categoryDisplayMap').update(
            buildCatDisplayMap(cfg.categories || []),
          );
        } else if (cfg.name === 'article_category') {
          getOutlet('articleCategories').update(cfg.categories || []);
          getOutlet('articleCategoryDisplayMap').update(
            buildCatDisplayMap(cfg.categories || []),
          );
        }
      }
    }
```