### PR TITLE
feat: add admin pending offline order page

### DIFF
--- a/content/admin/pending-offline-order.json
+++ b/content/admin/pending-offline-order.json
@@ -1,0 +1,111 @@
+{
+  "path": "/admin/orders/pending-offline-order",
+  "name": "待驗訂單",
+  "collection": "order",
+  "primaryKey": "id",
+  "searchFields": [
+    "order_number",
+    "buyer_name",
+    "buyer_phone"
+  ],
+  "searchApproach": "union",
+  "renderCreateButton": false,
+  "renderDeleteButton": false,
+  "renderDetailButton": false,
+  "resourceTableProps": {
+    "scroll": {
+      "x": 1200
+    }
+  },
+  "predefinedQueries": [
+    {
+      "payment_subtype": {
+        "$eq": "offline"
+      }
+    },
+    {
+      "offline_tx": {
+        "$ne": ""
+      }
+    },
+    {
+      "payment_status": {
+        "$eq": "pending"
+      }
+    }
+  ],
+  "columns": [
+    {
+      "title": "訂單編號",
+      "key": "order_number",
+      "dataIndex": "order_number",
+      "width": 200,
+      "fixed": "left"
+    },
+    {
+      "title": "購買人姓名",
+      "key": "buyer_name",
+      "dataIndex": "buyer_name",
+      "width": 150,
+      "fixed": "left"
+    },
+    {
+      "title": "帳號後五碼",
+      "key": "offline_tx",
+      "dataIndex": "offline_tx",
+      "customType": "offline_tx",
+      "width": 150,
+      "fixed": "left"
+    },
+    {
+      "title": "訂單狀態",
+      "key": "status",
+      "dataIndex": "status",
+      "customType": "order_status",
+      "width": 120
+    },
+    {
+      "title": "物流方式",
+      "key": "logistics_type",
+      "dataIndex": "logistics_type",
+      "customType": "logistics_type",
+      "width": 150
+    },
+    {
+      "title": "訂單日期",
+      "key": "created",
+      "dataIndex": "created",
+      "dataType": "timestamp",
+      "width": 130
+    },
+    {
+      "title": "客製單資訊",
+      "key": "custom_name",
+      "dataIndex": "custom_name",
+      "customType": "custom-order-info",
+      "width": 150
+    }
+  ],
+  "querySpec": {
+    "pageSizeOptions": [
+      50
+    ],
+    "sortOptions": [
+      {
+        "name": "日期近到遠",
+        "value": "-created"
+      },
+      {
+        "name": "日期遠到近",
+        "value": "created"
+      }
+    ],
+    "canSearch": true,
+    "filters": []
+  },
+  "formSpec": {
+    "schema": {},
+    "uiSchema": {}
+  },
+  "actionBar": []
+}

--- a/src/Components/AdminLayout/index.js
+++ b/src/Components/AdminLayout/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {useOutlet, useOutletSetter} from 'reconnect.js';
 import * as User from 'rev.sdk.js/Actions/User';
 import {navigate} from 'gatsby';
-import {Layout} from 'antd';
+import {Layout, Menu} from 'antd';
 import {withLoginRequired} from 'rev.sdk.js/Components/LoginRequired';
 import SiteNavBar from '../SiteNavBar';
 import LoginRequired from '../LoginRequired';
@@ -26,12 +26,13 @@ const SiteInfo = {
 const Routes = [
   {name: '首頁', path: '/admin'},
   {name: '會員', path: '/admin/users'},
-  {name: '文章', path: '/admin/articles'},
-  {name: '訂單', path: '/admin/orders'},
   {name: '商品', path: '/admin/products'},
   {name: '優惠券', path: '/admin/coupons'},
   {name: '滿額折扣', path: '/admin/discount-list'},
+  {name: '訂單首頁', path: '/admin/orders'},
+  {name: '待驗訂單', path: '/admin/orders/pending-offline-order'},
   {name: '客製化訂單', path: 'admin-custom-order'},
+  {name: '文章', path: '/admin/articles'},
   {name: '重設密碼', path: 'reset-password'},
   {name: '網站設定', path: '/admin/site'},
   {name: '超商地圖', path: '/admin/select-cvs'},
@@ -77,7 +78,6 @@ function AdminLayout(props) {
     height: '100vh',
     position: 'fixed',
     boxShadow: '0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23)',
-    transition: 200,
     left: 0,
   };
 
@@ -97,11 +97,44 @@ function AdminLayout(props) {
           onClick={() => navigate('/')}
         />
 
-        {Routes.map(({name, path}) => (
-          <MenuItem key={path} {...getMenuProps(path)}>
-            {name}
-          </MenuItem>
-        ))}
+        <Menu>
+          {Routes.filter(({name, path}) => path.indexOf('order') <= -1)
+            .slice(0, 5)
+            .map(({name, path}) => {
+              return (
+                <Menu.Item key={path} {...getMenuProps(path)}>
+                  {name}
+                </Menu.Item>
+              );
+            })}
+
+          <Menu.SubMenu key="orders" title="訂單">
+            {Routes.filter(({name, path}) => path.indexOf('order') > -1).map(
+              ({name, path}) => {
+                return (
+                  <Menu.Item key={path} {...getMenuProps(path)}>
+                    {name}
+                  </Menu.Item>
+                );
+              },
+            )}
+          </Menu.SubMenu>
+
+          {Routes.filter(({name, path}) => path.indexOf('order') <= -1)
+            .slice(5)
+            .map(({name, path}) => {
+              return (
+                <Menu.Item key={path} {...getMenuProps(path)}>
+                  {name}
+                </Menu.Item>
+              );
+            })}
+          {/*{Routes.map(({name, path}) => (*/}
+          {/*  <MenuItem key={path} {...getMenuProps(path)}>*/}
+          {/*    {name}*/}
+          {/*  </MenuItem>*/}
+          {/*))}*/}
+        </Menu>
       </Layout.Sider>
 
       <AdminCustomOrderModal />

--- a/src/Generators/AdminResource/index.js
+++ b/src/Generators/AdminResource/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import AdminResource from 'rev.sdk.js/Generators/AdminResource';
-import {Button, message, Select, Tag, Form, DatePicker} from 'antd';
+import {Button, DatePicker, Form, message, Popconfirm, Select, Tag} from 'antd';
 import {useOutlet} from 'reconnect.js';
 import AdminOrderDetailForm from './AdminOrderDetailForm';
 import ArticleEditor from 'rev.sdk.js/Components/ArticleEditor';
@@ -350,6 +350,12 @@ function AdminResourcePage(props) {
       return getLogisticsStatusCustomElem(record);
     } else if (col.customType === 'logistics_type') {
       return Cart.LOGISTICS_TYPE_DISPLAY[record.logistics_type]?.label;
+    } else if (col.customType === 'offline_tx') {
+      return (
+        <div style={{fontSize: 18, fontWeight: 'bold', letterSpacing: 2}}>
+          {record.offline_tx}
+        </div>
+      );
     }
     return null;
   }
@@ -368,6 +374,21 @@ function AdminResourcePage(props) {
           }}>
           編輯
         </Button>
+      );
+    };
+  } else if (path === '/admin/orders/pending-offline-order') {
+    pageContext.resource.renderDetailButton = (cfg, {refresh}) => {
+      return (
+        <Popconfirm
+          title="已經確認轉帳後五碼？"
+          onConfirm={async () => {
+            const _hide = message.loading('更新付款狀態...');
+            await AppActions.confirmOfflineOrder(cfg.id);
+            await refresh();
+            _hide();
+          }}>
+          <Button type="primary">驗證</Button>
+        </Popconfirm>
       );
     };
   }


### PR DESCRIPTION
- add the admin page for pending offline order 
- the page only have list view
- user can confirm offline order on list item

the page listing query logic below

```json
    {
      "payment_subtype": {
        "$eq": "offline"
      }
    },
    {
      "offline_tx": {
        "$ne": ""
      }
    },
    {
      "payment_status": {
        "$eq": "pending"
      }
    }
```