### PR TITLE
breaking: custom app outlets

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
-import './AppOutlets';
+import './AppOutlets/index';
+import './AppOutlets/custom';
 import './SdkInit';
 import {getOutlet} from 'reconnect.js';
 import * as AppActions from './AppActions/index';

--- a/src/AppOutlets/custom.js
+++ b/src/AppOutlets/custom.js
@@ -1,0 +1,3 @@
+import {getNewOutlet} from 'reconnect.js';
+
+getNewOutlet('extra', {}, {autoDelete: false});

--- a/src/AppOutlets/index.js
+++ b/src/AppOutlets/index.js
@@ -2,63 +2,16 @@ import {getNewOutlet} from 'reconnect.js';
 import {buildCatDisplayMap} from '../Utils/buildCatDisplayMap';
 import './featureOptions';
 
-// configurations for "product" collection
-const sortOptions = [
-  {name: 'pokemon_id', display: '編號(由低到高)'},
-  {name: '-pokemon_id', display: '編號(由高到低)'},
-  {name: '-created', display: '上架時間(由新到舊)'},
-  {name: 'created', display: '上架時間(由舊到新)'},
-  {name: 'price', display: '價格(由低到高)'},
-  {name: '-price', display: '價格(由高到低)'},
-];
-
-const categories = [
-  {
-    name: 'all',
-    display: '所有分類',
-    items: [],
-  },
-];
-
-// configurations for "Article_Default" collection
-const articleSortOptions = [
-  {name: '-created', display: '發布時間(由新到舊)'},
-  {name: 'created', display: '發布時間(由舊到新)'},
-];
-
-const articleCategories = [
-  {
-    name: 'all',
-    display: '所有分類',
-    items: [],
-  },
-];
-
+/**
+ * **************************************************
+ * common / basic
+ * **************************************************
+ */
 getNewOutlet('user', null, {autoDelete: false});
-getNewOutlet('loading', false, {autoDelete: false});
-getNewOutlet('login-modal', false, {autoDelete: false});
-getNewOutlet('reset-password-modal', false, {autoDelete: false});
-
 getNewOutlet('landing', null, {autoDelete: false});
-
-// product collection
-getNewOutlet('categories', categories, {autoDelete: false});
-getNewOutlet('categoryDisplayMap', buildCatDisplayMap(categories), {
-  autoDelete: false,
-});
-getNewOutlet('sortOptions', sortOptions, {autoDelete: false});
-
-// Article_Default collection
-getNewOutlet('articleCategories', articleCategories, {autoDelete: false});
-getNewOutlet(
-  'articleCategoryDisplayMap',
-  buildCatDisplayMap(articleCategories),
-  {
-    autoDelete: false,
-  },
-);
-getNewOutlet('articleSortOptions', articleSortOptions, {autoDelete: false});
-
+getNewOutlet('dimension', {rwd: 'mobile'}, {autoDelete: false});
+getNewOutlet('actions', null, {autoDelete: false});
+getNewOutlet('ApiUtil', {}, {autoDelete: false});
 getNewOutlet(
   'cart',
   {
@@ -68,9 +21,6 @@ getNewOutlet(
   },
   {autoDelete: false},
 );
-getNewOutlet('dimension', {rwd: 'mobile'}, {autoDelete: false});
-getNewOutlet('actions', null, {autoDelete: false});
-getNewOutlet('ApiUtil', {}, {autoDelete: false});
 getNewOutlet(
   'routes',
   {
@@ -78,5 +28,55 @@ getNewOutlet(
       return null;
     },
   },
+  {autoDelete: false},
+);
+
+/**
+ * **************************************************
+ * modal / spinner related
+ * **************************************************
+ */
+getNewOutlet('loading', false, {autoDelete: false});
+getNewOutlet('login-modal', false, {autoDelete: false});
+getNewOutlet('reset-password-modal', false, {autoDelete: false});
+
+/**
+ * **************************************************
+ * product / article related
+ * **************************************************
+ */
+const defaultCats = [
+  {
+    name: 'all',
+    display: '所有分類',
+    items: [],
+  },
+];
+
+getNewOutlet('categories', defaultCats, {autoDelete: false});
+getNewOutlet('categoryDisplayMap', buildCatDisplayMap(defaultCats), {
+  autoDelete: false,
+});
+getNewOutlet(
+  'sortOptions',
+  [
+    {name: '-created', display: '上架時間(由新到舊)'},
+    {name: 'created', display: '上架時間(由舊到新)'},
+    {name: 'price', display: '價格(由低到高)'},
+    {name: '-price', display: '價格(由高到低)'},
+  ],
+  {autoDelete: false},
+);
+
+getNewOutlet('articleCategories', defaultCats, {autoDelete: false});
+getNewOutlet('articleCategoryDisplayMap', buildCatDisplayMap(defaultCats), {
+  autoDelete: false,
+});
+getNewOutlet(
+  'articleSortOptions',
+  [
+    {name: '-created', display: '發布時間(由新到舊)'},
+    {name: 'created', display: '發布時間(由舊到新)'},
+  ],
   {autoDelete: false},
 );


### PR DESCRIPTION
**WARNING: Breaking change!!**

This PR add `src/AppOutlets/custom.js` to allow projects:
- customize existing outlet
- create new outlet

Checkout the initialization step in `App.js`, we have sourced both `src/AppOutlets/index` and `src/AppOutlets/custom` in it: (just like `AppActions`)
```javascript
import './AppOutlets/index';
import './AppOutlets/custom';
import './SdkInit';
import {getOutlet} from 'reconnect.js';
import * as AppActions from './AppActions/index';
import * as CustomActions from './AppActions/custom';

const ActionOutlet = getOutlet('actions');

ActionOutlet.update({
  ...AppActions,
  ...CustomActions,
});

console.log('App initialized');
```

> Since the `AppOutlets/index` is imported **BEFORE** `AppOutlets/custom`, so we can simply use `getOutlet(<name>).update()` To customize existing outlet's value 

> On the otherhand, if we'd like to create new outlet, simply use `getNewOutlet()`